### PR TITLE
Add a basic integration test to verify agent loop with tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,3 +17,4 @@ jobs:
       - run: dart analyze
       - run: dart format --set-exit-if-changed .
       - run: dart test
+      - run: dart test integration_test

--- a/integration_test/agent_loop_with_tools_test.dart
+++ b/integration_test/agent_loop_with_tools_test.dart
@@ -1,0 +1,94 @@
+import 'package:bart/api/client.dart';
+import 'package:bart/api/ollama_client.dart';
+import 'package:bart/tools/tool_set.dart';
+import 'package:file/file.dart';
+import 'package:logging/logging.dart';
+import 'package:test/test.dart';
+
+import '../test/support/utils.dart';
+import 'support/test_agent.dart';
+import 'support/test_client.dart';
+import 'support/utils.dart';
+
+const mode = TestMode.recordSnapshots;
+
+const logLevel = Level.FINE;
+
+void main() {
+  _setUpLogging();
+
+  group('Agent Loop with Tools', () {
+    late final Directory tempProjectDir;
+    late final TestApiClient client;
+    late final ApiClient? realApi;
+    late final TestAgent agent;
+
+    const readmeFilename = 'README.md';
+    final readmeFile = fileSystem.file(readmeFilename);
+    const testPhrase = 'The cat sat on the mat';
+
+    setUp(() {
+      tempProjectDir = fileSystem.systemTempDirectory.createTempSync('bart_test_');
+      fileSystem.currentDirectory = tempProjectDir;
+
+      realApi = (mode == TestMode.useLlm || mode == TestMode.recordSnapshots)
+          ? OllamaClient(model: 'gpt-oss:20b')
+          : null;
+      client = TestApiClient(
+        realClient: realApi,
+        dataDirectory: dataDirectory,
+        mode: mode,
+      );
+    });
+
+    tearDown(() async {
+      await agent.provideInput(null);
+      tryDelete(tempProjectDir);
+    });
+
+    test('Use create, edit, read, delete tools', () async {
+      expect(readmeFile.existsSync(), isFalse); // Ensure initial state.
+
+      agent = TestAgent.start(
+        client: client,
+        fileSystem: fileSystem,
+        allowedDirectories: {tempProjectDir},
+        tools: ToolSet.fileTools(fileSystem),
+      );
+
+      // Create
+      await agent.provideInput('Create a $readmeFilename file with the content "Hello World".');
+      expect(agent.lastToolCall.toolName, 'create_file');
+      expect(readmeFile.readAsStringSync(), 'Hello World');
+
+      // Edit
+      await agent.provideInput(
+        'Edit the $readmeFilename file to change "Hello World" to "Hello Universe".',
+      );
+      expect(agent.lastToolCall.toolName, 'edit_file');
+      expect(readmeFile.readAsStringSync(), 'Hello Universe');
+
+      readmeFile.writeAsStringSync(testPhrase);
+      await agent.provideInput(
+        'I modified $readmeFilename to verify your read tool. Please return the contents.',
+      );
+      expect(agent.lastToolCall.toolName, 'read_file');
+      expect(agent.lastAssistantMessage, contains(testPhrase));
+
+      // Delete
+      await agent.provideInput('Delete the $readmeFilename file.');
+      expect(agent.lastToolCall.toolName, 'delete_file');
+      expect(readmeFile.existsSync(), isFalse);
+    });
+  });
+}
+
+void _setUpLogging() {
+  Logger.root.level = logLevel;
+  Logger.root.onRecord.listen((record) {
+    final prefix = '${record.level.name}: ${record.time}: ';
+    final text = record.message.split('\n').join('\n${' ' * prefix.length}');
+    final message = '$prefix$text';
+    print(message);
+  });
+}

--- a/integration_test/agent_loop_with_tools_test.dart
+++ b/integration_test/agent_loop_with_tools_test.dart
@@ -10,7 +10,7 @@ import 'support/test_agent.dart';
 import 'support/test_client.dart';
 import 'support/utils.dart';
 
-const mode = TestMode.recordSnapshots;
+const mode = TestMode.useSnapshots;
 
 const logLevel = Level.FINE;
 

--- a/integration_test/agent_loop_with_tools_test.dart
+++ b/integration_test/agent_loop_with_tools_test.dart
@@ -14,15 +14,18 @@ const mode = TestMode.useSnapshots;
 
 const logLevel = Level.FINE;
 
+late final Directory tempProjectDir;
+late final TestApiClient client;
+late final ApiClient? realApi;
+late final TestAgent? _agent;
+
+TestAgent get agent => _agent!;
+set agent(TestAgent agent) => _agent = agent;
+
 void main() {
   _setUpLogging();
 
   group('Agent Loop with Tools', () {
-    late final Directory tempProjectDir;
-    late final TestApiClient client;
-    late final ApiClient? realApi;
-    late final TestAgent agent;
-
     const readmeFilename = 'README.md';
     final readmeFile = fileSystem.file(readmeFilename);
     const testPhrase = 'The cat sat on the mat';
@@ -42,7 +45,7 @@ void main() {
     });
 
     tearDown(() async {
-      await agent.provideInput(null);
+      await _agent?.provideInput(null);
       tryDelete(tempProjectDir);
     });
 

--- a/integration_test/data/agent_loop_with_tools_use_create_edit_read_delete_tools.json
+++ b/integration_test/data/agent_loop_with_tools_use_create_edit_read_delete_tools.json
@@ -1,0 +1,143 @@
+{
+	"messages": [
+		{
+			"role": "user",
+			"content": "Create a README.md file with the content \"Hello World\".",
+			"toolCallId": null,
+			"toolCalls": null
+		},
+		{
+			"role": "assistant",
+			"content": "",
+			"toolCallId": null,
+			"toolCalls": [
+				{
+					"id": "toolCall_1",
+					"function": {
+						"name": "create_file",
+						"arguments": {
+							"content": "Hello World",
+							"file_path": "README.md"
+						}
+					}
+				}
+			]
+		},
+		{
+			"role": "tool",
+			"content": "File \"README.md\" created successfully.",
+			"toolCallId": "toolCall_2",
+			"toolCalls": null
+		},
+		{
+			"role": "assistant",
+			"content": "The file `README.md` has been created with the content:\n\n```\nHello World\n```\n\nYou can now open it to confirm the contents.",
+			"toolCallId": null,
+			"toolCalls": null
+		},
+		{
+			"role": "user",
+			"content": "Edit the README.md file to change \"Hello World\" to \"Hello Universe\".",
+			"toolCallId": null,
+			"toolCalls": null
+		},
+		{
+			"role": "assistant",
+			"content": "",
+			"toolCallId": null,
+			"toolCalls": [
+				{
+					"id": "toolCall_3",
+					"function": {
+						"name": "edit_file",
+						"arguments": {
+							"file_path": "README.md",
+							"new_string": "Hello Universe",
+							"old_string": "Hello World"
+						}
+					}
+				}
+			]
+		},
+		{
+			"role": "tool",
+			"content": "File \"README.md\" successfully edited.",
+			"toolCallId": "toolCall_4",
+			"toolCalls": null
+		},
+		{
+			"role": "assistant",
+			"content": "The content of `README.md` has been updated from **Hello World** to **Hello Universe**.",
+			"toolCallId": null,
+			"toolCalls": null
+		},
+		{
+			"role": "user",
+			"content": "I modified README.md to verify your read tool. Please return the contents.",
+			"toolCallId": null,
+			"toolCalls": null
+		},
+		{
+			"role": "assistant",
+			"content": "",
+			"toolCallId": null,
+			"toolCalls": [
+				{
+					"id": "toolCall_5",
+					"function": {
+						"name": "read_file",
+						"arguments": {
+							"file_path": "README.md"
+						}
+					}
+				}
+			]
+		},
+		{
+			"role": "tool",
+			"content": "The cat sat on the mat",
+			"toolCallId": "toolCall_6",
+			"toolCalls": null
+		},
+		{
+			"role": "assistant",
+			"content": "The contents of `README.md` are:\n\n```\nThe cat sat on the mat\n```",
+			"toolCallId": null,
+			"toolCalls": null
+		},
+		{
+			"role": "user",
+			"content": "Delete the README.md file.",
+			"toolCallId": null,
+			"toolCalls": null
+		},
+		{
+			"role": "assistant",
+			"content": "",
+			"toolCallId": null,
+			"toolCalls": [
+				{
+					"id": "toolCall_7",
+					"function": {
+						"name": "delete_file",
+						"arguments": {
+							"file_path": "README.md"
+						}
+					}
+				}
+			]
+		},
+		{
+			"role": "tool",
+			"content": "File \"README.md\" deleted successfully.",
+			"toolCallId": "toolCall_8",
+			"toolCalls": null
+		},
+		{
+			"role": "assistant",
+			"content": "The file `README.md` has been deleted.",
+			"toolCallId": null,
+			"toolCalls": null
+		}
+	]
+}

--- a/integration_test/support/test_agent.dart
+++ b/integration_test/support/test_agent.dart
@@ -1,0 +1,94 @@
+import 'dart:async';
+
+import 'package:bart/agents/agent.dart';
+import 'package:bart/output_message.dart';
+import 'package:file/file.dart';
+
+/// An implementation of [Agent] for integration testing.
+///
+/// Allows controlling the agent's input and inspecting outputs.
+class TestAgent extends Agent {
+  @override
+  final Set<Directory> allowedDirectories;
+
+  /// The last tool call made by the assistant.
+  ToolCall get lastToolCall => _lastToolCall ?? (throw 'No tool calls made');
+  ToolCall? _lastToolCall;
+
+  /// The last output message from the assistant.
+  String get lastAssistantMessage => _lastAssistantMessage ?? (throw 'No assistant messages');
+  String? _lastAssistantMessage;
+
+  Completer<String?>? _inputCompleter;
+  Completer<void>? _readyCompleter;
+  Future<void>? _runFuture;
+
+  /// Creates a [TestAgent] and immediately starts it running which will result in a request for user input.
+  ///
+  /// Input can be provided by calling [provideInput].
+  TestAgent.start({
+    required super.client,
+    super.systemMessage,
+    required super.fileSystem,
+    required this.allowedDirectories,
+    required super.tools,
+  }) {
+    _runFuture = run();
+  }
+
+  @override
+  void startWorking(String reason) {
+    log.finest('Starting work: $reason');
+  }
+
+  @override
+  void stopWorking() {
+    log.finest('Stopping work');
+  }
+
+  @override
+  Future<String?> getUserMessage() {
+    // The agent asked for input, so we complete the `provideInput()` completer to signal to the test that
+    // the round of conversation from the last input is done. This allows it to perform tests before
+    // providing the next input.
+    _readyCompleter?.complete();
+
+    // Create a completer allow the test to provide the next input later.
+    return (_inputCompleter = Completer<String?>()).future;
+  }
+
+  /// Provide input to the agent and run until it waits for the next input.
+  Future<void> provideInput(String? message) async {
+    final completer = _inputCompleter;
+    if (completer == null || completer.isCompleted) {
+      throw 'The agent is not waiting for input!';
+    }
+
+    // Send the message.
+    log.fine('You: ${message ?? '(end)'}');
+    completer.complete(message);
+
+    // If it was a normal message, wait for it to be send and handled.
+    if (message != null) {
+      await (_readyCompleter = Completer<void>()).future;
+    }
+  }
+
+  @override
+  void showOutput(OutputMessage message) {
+    switch (message) {
+      case ToolCall():
+        _lastToolCall = message;
+      case AssistantMessage():
+        log.fine('Assistant: ${message.content}');
+        _lastAssistantMessage = message.content;
+      default:
+    }
+  }
+
+  /// Ends the agent session.
+  Future<void> end() async {
+    await provideInput(null);
+    await _runFuture;
+  }
+}

--- a/integration_test/support/test_agent.dart
+++ b/integration_test/support/test_agent.dart
@@ -12,11 +12,13 @@ class TestAgent extends Agent {
   final Set<Directory> allowedDirectories;
 
   /// The last tool call made by the assistant.
-  ToolCall get lastToolCall => _lastToolCall ?? (throw 'No tool calls made');
+  ToolCall get lastToolCall =>
+      _lastToolCall ?? (throw StateError('No tool calls have been made yet.'));
   ToolCall? _lastToolCall;
 
   /// The last output message from the assistant.
-  String get lastAssistantMessage => _lastAssistantMessage ?? (throw 'No assistant messages');
+  String get lastAssistantMessage =>
+      _lastAssistantMessage ?? (throw StateError('No assistant messages have been received yet.'));
   String? _lastAssistantMessage;
 
   Completer<String?>? _inputCompleter;
@@ -61,7 +63,7 @@ class TestAgent extends Agent {
   Future<void> provideInput(String? message) async {
     final completer = _inputCompleter;
     if (completer == null || completer.isCompleted) {
-      throw 'The agent is not waiting for input!';
+      throw StateError('The agent is not waiting for input!');
     }
 
     // Send the message.

--- a/integration_test/support/test_client.dart
+++ b/integration_test/support/test_client.dart
@@ -96,7 +96,7 @@ class TestApiClient implements ApiClient {
   APIResponse _loadAndValidateResponse(List<Message> incomingMessages, int callIndex) {
     final file = dataDirectory.childFile('$conversationId.json');
     if (!file.existsSync()) {
-      throw Exception(
+      throw StateError(
         'No saved conversation found for conversationId: $conversationId in "${file.path}"',
       );
     }

--- a/integration_test/support/test_client.dart
+++ b/integration_test/support/test_client.dart
@@ -1,0 +1,228 @@
+import 'dart:convert';
+
+import 'package:bart/api/client.dart';
+import 'package:bart/api/types.dart';
+import 'package:file/file.dart';
+import 'package:test_api/src/backend/invoker.dart';
+
+/// A test client that can either record real API responses or replay captured ones.
+///
+/// When [mode] is [TestMode.useSnapshots], it loads saved responses.
+/// When [mode] is [TestMode.useLlm], it uses the real API without saving.
+/// When [mode] is [TestMode.recordSnapshots], it uses the real API and saves responses.
+class TestApiClient implements ApiClient {
+  final ApiClient? realClient;
+  final Directory dataDirectory;
+  final TestMode mode;
+  final String conversationId;
+
+  var _toolCallIndex = 1;
+  var _callIndex = 0;
+
+  TestApiClient({
+    this.realClient,
+    required this.dataDirectory,
+    required this.mode,
+    String? conversationId,
+  }) : conversationId = (conversationId ?? Invoker.current!.liveTest.test.name)
+           .toLowerCase()
+           .replaceAll(
+             RegExp('[^a-z0-9]+'),
+             '_',
+           );
+
+  @override
+  Future<APIResponse> callAPI(
+    List<Message> messages,
+    List<ToolDefinition> tools,
+  ) async {
+    if (mode == TestMode.useSnapshots) {
+      // Load and validate the conversation
+      return _loadAndValidateResponse(messages, _callIndex++);
+    } else {
+      // Use real API
+      final response = await realClient!.callAPI(messages, tools);
+      if (mode == TestMode.recordSnapshots) {
+        _saveResponse(_callIndex++, messages, response);
+      }
+      return response;
+    }
+  }
+
+  APIResponse _normalizeResponse(APIResponse response) {
+    return APIResponse(
+      choices: response.choices.map((choice) {
+        return Choice(
+          message: Message(
+            role: choice.message.role,
+            content: choice.message.content,
+            toolCallId: choice.message.toolCallId,
+            toolCalls: choice.message.toolCalls?.map((toolCall) {
+              return ToolCall(
+                id: 'toolCall_${_toolCallIndex++}',
+                function: toolCall.function,
+              );
+            }).toList(),
+          ),
+        );
+      }).toList(),
+    );
+  }
+
+  void _saveResponse(int callIndex, List<Message> messages, APIResponse response) {
+    final file = dataDirectory.childFile('$conversationId.json');
+    file.parent.createSync(recursive: true);
+
+    // Reset tool call index for deterministic IDs
+    _toolCallIndex = 1;
+
+    // Create the full conversation: all input messages + the new response
+    final conversation = <Map<String, Object?>>[];
+
+    // Add all input messages
+    for (final message in messages) {
+      conversation.add(_messageToJson(_normalizeMessage(message)));
+    }
+
+    // Add the assistant response
+    final normalizedResponse = _normalizeResponse(response);
+    conversation.add(_messageToJson(normalizedResponse.choices.first.message));
+
+    final json = {'messages': conversation};
+    const encoder = JsonEncoder.withIndent('\t');
+    file.writeAsStringSync(encoder.convert(json));
+  }
+
+  APIResponse _loadAndValidateResponse(List<Message> incomingMessages, int callIndex) {
+    final file = dataDirectory.childFile('$conversationId.json');
+    if (!file.existsSync()) {
+      throw Exception(
+        'No saved conversation found for conversationId: $conversationId in "${file.path}"',
+      );
+    }
+    final json = jsonDecode(file.readAsStringSync()) as Map<String, Object?>;
+    final storedMessagesJson = json['messages']! as List<Object?>;
+
+    // Reset tool call index for normalization
+    _toolCallIndex = 1;
+
+    // Normalize incoming messages for comparison
+    final normalizedIncomingMessages = incomingMessages.map(_normalizeMessage).toList();
+
+    if (normalizedIncomingMessages.length > storedMessagesJson.length) {
+      throw Exception(
+        'Incoming message count (${normalizedIncomingMessages.length}) exceeds stored conversation length (${storedMessagesJson.length}) in "$conversationId"',
+      );
+    }
+
+    for (var i = 0; i < normalizedIncomingMessages.length; i++) {
+      final incomingMessage = normalizedIncomingMessages[i];
+      final storedMessageJson = storedMessagesJson[i]! as Map<String, Object?>;
+      final storedMessage = _messageFromJson(storedMessageJson);
+
+      if (incomingMessage.role != storedMessage.role) {
+        throw Exception(
+          'Message role mismatch at position $i in conversation "$conversationId". '
+          'Expected: ${storedMessage.role}, Got: ${incomingMessage.role}',
+        );
+      }
+
+      if (incomingMessage.role == 'user') {
+        // For user messages, validate content matches
+        if (incomingMessage.content != storedMessage.content) {
+          throw Exception(
+            'User message content mismatch at position $i in conversation "$conversationId". '
+            'Expected: ${storedMessage.content}, Got: ${incomingMessage.content}',
+          );
+        }
+      } else if (incomingMessage.role == 'tool') {
+        // For tool messages, validate toolCallId matches but allow content to differ
+        // (content may contain dynamic paths or other runtime-specific data)
+        if (incomingMessage.toolCallId != storedMessage.toolCallId) {
+          throw Exception(
+            'Tool message toolCallId mismatch at position $i in conversation "$conversationId". '
+            'Expected: ${storedMessage.toolCallId}, Got: ${incomingMessage.toolCallId}',
+          );
+        }
+      }
+      // For assistant messages, we don't validate content since that's what we're replaying
+    }
+
+    // Find the next assistant message after the incoming messages
+    for (var i = normalizedIncomingMessages.length; i < storedMessagesJson.length; i++) {
+      final storedMessageJson = storedMessagesJson[i]! as Map<String, Object?>;
+      final storedMessage = _messageFromJson(storedMessageJson);
+      if (storedMessage.role == 'assistant') {
+        return APIResponse(choices: [Choice(message: storedMessage)]);
+      }
+    }
+
+    throw Exception(
+      'No assistant response found after ${normalizedIncomingMessages.length} messages in conversation "$conversationId"',
+    );
+  }
+
+  Map<String, Object?> _messageToJson(Message message) {
+    return {
+      'role': message.role,
+      'content': message.content,
+      'toolCallId': message.toolCallId,
+      'toolCalls': message.toolCalls
+          ?.map(
+            (toolCall) => {
+              'id': toolCall.id,
+              'function': {
+                'name': toolCall.function.name,
+                'arguments': toolCall.function.arguments,
+              },
+            },
+          )
+          .toList(),
+    };
+  }
+
+  Message _messageFromJson(Map<String, Object?> json) {
+    final toolCallsJson = (json['toolCalls'] as List<Object?>?)?.cast<Map<String, Object?>>();
+    return Message(
+      role: json['role']! as String,
+      content: json['content'] as String?,
+      toolCallId: json['toolCallId'] as String?,
+      toolCalls: toolCallsJson?.map((toolCallJson) {
+        final functionJson = toolCallJson['function']! as Map<String, Object?>;
+        return ToolCall(
+          id: toolCallJson['id']! as String,
+          function: ToolFunctionCall(
+            name: functionJson['name']! as String,
+            arguments: functionJson['arguments'] as Map<String, Object?>?,
+          ),
+        );
+      }).toList(),
+    );
+  }
+
+  Message _normalizeMessage(Message message) {
+    return Message(
+      role: message.role,
+      content: message.content,
+      toolCallId: message.toolCallId != null ? 'toolCall_${_toolCallIndex++}' : null,
+      toolCalls: message.toolCalls?.map((toolCall) {
+        return ToolCall(
+          id: 'toolCall_${_toolCallIndex++}',
+          function: toolCall.function,
+        );
+      }).toList(),
+    );
+  }
+}
+
+/// Modes for the test client behavior.
+enum TestMode {
+  /// Use saved snapshots for responses.
+  useSnapshots,
+
+  /// Use the real LLM API without saving responses.
+  useLlm,
+
+  /// Use the real API and save responses as snapshots for future runs.
+  recordSnapshots,
+}

--- a/integration_test/support/utils.dart
+++ b/integration_test/support/utils.dart
@@ -1,0 +1,15 @@
+import 'dart:io' show Platform;
+
+import 'package:file/local.dart';
+import 'package:file/memory.dart';
+import 'package:path/path.dart' as path;
+
+import '../../test/support/utils.dart';
+
+final dataDirectory = const LocalFileSystem().directory(
+  path.join(packageRoot, 'integration_test', 'data'),
+);
+
+final fileSystem = MemoryFileSystem(
+  style: Platform.isWindows ? FileSystemStyle.windows : FileSystemStyle.posix,
+);

--- a/lib/agents/agent.dart
+++ b/lib/agents/agent.dart
@@ -16,7 +16,7 @@ abstract class Agent {
   final log = Logger('Agent');
 
   @protected
-  final jsonEncode = const JsonEncoder.withIndent('    ').convert;
+  final jsonEncode = const JsonEncoder.withIndent('\t').convert;
 
   /// A client for accessing an LLM.
   final ApiClient client;

--- a/lib/api/openai_client.dart
+++ b/lib/api/openai_client.dart
@@ -11,7 +11,7 @@ final _log = Logger('OpenAIClient');
 class OpenAIClient implements ApiClient {
   final String apiUrl, apiKey, model;
 
-  final jsonEncode = const JsonEncoder.withIndent('    ').convert;
+  final jsonEncode = const JsonEncoder.withIndent('\t').convert;
 
   OpenAIClient({
     required this.apiUrl,

--- a/test/support/utils.dart
+++ b/test/support/utils.dart
@@ -1,0 +1,15 @@
+import 'dart:isolate';
+
+import 'package:file/file.dart';
+
+void tryDelete(Directory directory) {
+  try {
+    directory.deleteSync(recursive: true);
+  } catch (_) {
+    // Ignore file locking errors on Windows.
+  }
+}
+
+final packageRoot = Isolate.resolvePackageUriSync(
+  Uri.parse('package:bart/'),
+)!.resolve('..').toFilePath();


### PR DESCRIPTION
Adds a test that runs the agent with multiple user prompts and verify tool use.

By default, the tests run using a snapshot for responses in `integration_test/data` but can be run (currently by modifying the `mode` variable) to run against a real LLM and update/create the snapshots.